### PR TITLE
Update installation.md to include a clarification on the instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,11 @@ You can gain access to NGINX Kubernetes Gateway by creating a `NodePort` Service
 > configured for those ports. If you'd like to use different ports in your listeners,
 > update the manifests accordingly.
 
+> Important
+>
+> NGINX Kubernetes Gateway will not listen on any ports until you configure a
+> [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/#gateway) resource with a valid listener.
+
 ### Create a NodePort Service
 
 Create a Service with type `NodePort`:


### PR DESCRIPTION
Add a note that a gateway resource must be configured in order for the NGINX Kubernetes Gateway to start listening on the assigned ports.

### Proposed changes

Problem: I followed the installation instructions and then spent time debugging why I couldn't reach the nginx server using the NodePort.

Solution: Add a note to the instructions that a gateway resource must be configured. A similar note is already contained in the kind installation instructions but not in the generic installation guide.

Testing: N/A

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
